### PR TITLE
Fix panic when faces to extrude have no normal

### DIFF
--- a/src/mesh/halfedge.rs
+++ b/src/mesh/halfedge.rs
@@ -688,16 +688,15 @@ impl HalfEdgeMesh {
     // Returns the normal of the face. The first three vertices are used to
     // compute the normal. If the vertices of the face are not coplanar,
     // the result will not be correct.
-    fn face_normal(&self, face: FaceId) -> Vec3 {
+    fn face_normal(&self, face: FaceId) -> Option<Vec3> {
         let verts = self.face_vertices(face);
-        // Will panic if face has two or less vertices. Note that faces with two
-        // vertices are possible (they get generated as part of the bevel
-        // operation). But this would only fail if the operation is used on one
-        // such face in the middle of an operation, not in normal operation.
-        let v01 = self.vertex_position(verts[0]) - self.vertex_position(verts[1]);
-        let v12 = self.vertex_position(verts[1]) - self.vertex_position(verts[2]);
-
-        v01.cross(v12).normalize()
+        if verts.len() >= 3 {
+            let v01 = self.vertex_position(verts[0]) - self.vertex_position(verts[1]);
+            let v12 = self.vertex_position(verts[1]) - self.vertex_position(verts[2]);
+            Some(v01.cross(v12).normalize())
+        } else {
+            None
+        }
     }
 }
 

--- a/src/mesh/halfedge/edit_ops.rs
+++ b/src/mesh/halfedge/edit_ops.rs
@@ -867,7 +867,10 @@ pub fn extrude_faces(mesh: &mut HalfEdgeMesh, faces: &[FaceId], amount: f32) -> 
 
             mesh.add_debug_halfedge(h, DebugMark::green("bvl"));
 
-            let push = mesh.face_normal(face) * amount;
+            let push = mesh
+                .face_normal(face)
+                .ok_or_else(|| anyhow!("Attempted to extrude a face with only two vertices."))?
+                * amount;
 
             move_ops
                 .entry(src)


### PR DESCRIPTION
This prevents the panic in #2. Although the root cause  still needs to be fixed.