### PR TITLE
Add properties inspector and spreadsheet view

### DIFF
--- a/src/app_window/input.rs
+++ b/src/app_window/input.rs
@@ -69,17 +69,14 @@ impl InputSystem {
                     .on_cursor_move(Vec2::new(position.x as f32, position.y as f32));
             }
             // Wheel events will only get registered when the cursor is inside the viewport
-            WindowEvent::MouseWheel { delta, .. } if mouse_in_viewport => {
-                println!("[3d viewport] {:?}", delta);
-                match delta {
-                    winit::event::MouseScrollDelta::LineDelta(_, y) => {
-                        self.mouse.on_wheel_scroll(*y as f32);
-                    }
-                    winit::event::MouseScrollDelta::PixelDelta(pos) => {
-                        self.mouse.on_wheel_scroll(pos.y as f32);
-                    }
+            WindowEvent::MouseWheel { delta, .. } if mouse_in_viewport => match delta {
+                winit::event::MouseScrollDelta::LineDelta(_, y) => {
+                    self.mouse.on_wheel_scroll(*y as f32);
                 }
-            }
+                winit::event::MouseScrollDelta::PixelDelta(pos) => {
+                    self.mouse.on_wheel_scroll(pos.y as f32);
+                }
+            },
             // Button events are a bit different: Presses can register inside
             // the viewport but releases will register anywhere.
             WindowEvent::MouseInput {

--- a/src/app_window/input.rs
+++ b/src/app_window/input.rs
@@ -69,14 +69,17 @@ impl InputSystem {
                     .on_cursor_move(Vec2::new(position.x as f32, position.y as f32));
             }
             // Wheel events will only get registered when the cursor is inside the viewport
-            WindowEvent::MouseWheel { delta, .. } if mouse_in_viewport => match delta {
-                winit::event::MouseScrollDelta::LineDelta(_, y) => {
-                    self.mouse.on_wheel_scroll(*y as f32);
+            WindowEvent::MouseWheel { delta, .. } if mouse_in_viewport => {
+                println!("[3d viewport] {:?}", delta);
+                match delta {
+                    winit::event::MouseScrollDelta::LineDelta(_, y) => {
+                        self.mouse.on_wheel_scroll(*y as f32);
+                    }
+                    winit::event::MouseScrollDelta::PixelDelta(pos) => {
+                        self.mouse.on_wheel_scroll(pos.y as f32);
+                    }
                 }
-                winit::event::MouseScrollDelta::PixelDelta(pos) => {
-                    self.mouse.on_wheel_scroll(pos.y as f32);
-                }
-            },
+            }
             // Button events are a bit different: Presses can register inside
             // the viewport but releases will register anywhere.
             WindowEvent::MouseInput {

--- a/src/app_window/input.rs
+++ b/src/app_window/input.rs
@@ -45,7 +45,11 @@ impl InputSystem {
         let mouse_in_viewport = self
             .mouse
             .last_pos_raw
-            .map(|pos| viewport_rect.contains(egui::pos2(pos.x, pos.y)))
+            .map(|pos| {
+                viewport_rect
+                    .scale_from_origin(parent_scale)
+                    .contains(egui::pos2(pos.x, pos.y))
+            })
             .unwrap_or(false);
 
         match event {

--- a/src/application.rs
+++ b/src/application.rs
@@ -7,7 +7,7 @@ use egui_winit_platform::{Platform, PlatformDescriptor};
 
 use self::{
     app_viewport::AppViewport, application_context::ApplicationContext, graph_editor::GraphEditor,
-    root_ui::AppRootAction, viewport_3d::Viewport3d,
+    inspector::InspectorTabs, root_ui::AppRootAction, viewport_3d::Viewport3d,
 };
 
 pub struct RootViewport {
@@ -19,6 +19,7 @@ pub struct RootViewport {
     viewport_3d: Viewport3d,
     /// Stores the egui texture ids for the child viewports.
     offscreen_viewports: HashMap<OffscreenViewport, AppViewport>,
+    inspector_tabs: InspectorTabs,
 }
 
 /// The application context is state that is global to an instance of blackjack.
@@ -46,6 +47,9 @@ pub mod app_viewport;
 
 /// An egui container to draw a recursive tree of resizable horizontal/vertical splits
 pub mod viewport_split;
+
+/// The properties and spreadsheet inspector code
+pub mod inspector;
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 enum OffscreenViewport {
@@ -86,6 +90,7 @@ impl RootViewport {
             graph_editor: GraphEditor::new(&renderer.device, window_size, screen_format),
             viewport_3d: Viewport3d::new(),
             offscreen_viewports,
+            inspector_tabs: InspectorTabs::new(),
         }
     }
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -88,7 +88,7 @@ impl RootViewport {
             },
             renderpass: RenderPass::new(&renderer.device, screen_format, 1),
             app_context: ApplicationContext::new(renderer),
-            graph_editor: GraphEditor::new(&renderer.device, window_size, screen_format),
+            graph_editor: GraphEditor::new(&renderer.device, window_size, screen_format, scale_factor as f32),
             viewport_3d: Viewport3d::new(),
             offscreen_viewports,
             inspector_tabs: InspectorTabs::new(),

--- a/src/application.rs
+++ b/src/application.rs
@@ -88,7 +88,12 @@ impl RootViewport {
             },
             renderpass: RenderPass::new(&renderer.device, screen_format, 1),
             app_context: ApplicationContext::new(renderer),
-            graph_editor: GraphEditor::new(&renderer.device, window_size, screen_format, scale_factor as f32),
+            graph_editor: GraphEditor::new(
+                &renderer.device,
+                window_size,
+                screen_format,
+                scale_factor as f32,
+            ),
             viewport_3d: Viewport3d::new(),
             offscreen_viewports,
             inspector_tabs: InspectorTabs::new(),

--- a/src/application.rs
+++ b/src/application.rs
@@ -20,6 +20,7 @@ pub struct RootViewport {
     /// Stores the egui texture ids for the child viewports.
     offscreen_viewports: HashMap<OffscreenViewport, AppViewport>,
     inspector_tabs: InspectorTabs,
+    diagnostics_open: bool,
 }
 
 /// The application context is state that is global to an instance of blackjack.
@@ -91,6 +92,7 @@ impl RootViewport {
             viewport_3d: Viewport3d::new(),
             offscreen_viewports,
             inspector_tabs: InspectorTabs::new(),
+            diagnostics_open: false,
         }
     }
 
@@ -164,7 +166,7 @@ impl RootViewport {
         self.platform.begin_frame();
 
         egui::TopBottomPanel::top("top_menubar").show(&self.platform.context(), |ui| {
-            if let Some(menubar_action) = Self::top_menubar(ui) {
+            if let Some(menubar_action) = self.top_menubar(ui) {
                 actions.push(menubar_action);
             }
         });
@@ -174,6 +176,8 @@ impl RootViewport {
             split_tree.show(ui, self, Self::show_leaf);
             self.app_context.split_tree = split_tree;
         });
+
+        self.diagnostics_ui(&self.platform.context());
 
         self.app_context.update(
             &self.platform.context(),

--- a/src/application/graph_editor.rs
+++ b/src/application/graph_editor.rs
@@ -83,6 +83,7 @@ impl GraphEditor {
                     );
                 }
                 winit::event::WindowEvent::MouseWheel { delta, .. } if mouse_in_viewport => {
+                    println!("[Node Editor] {:?}", delta);
                     let mouse_pos = if let Some(raw_pos) = self.raw_mouse_position {
                         viewport_relative_position(
                             raw_pos.to_winit(),

--- a/src/application/graph_editor.rs
+++ b/src/application/graph_editor.rs
@@ -15,7 +15,12 @@ impl GraphEditor {
     pub const ZOOM_LEVEL_MIN: f32 = 0.5;
     pub const ZOOM_LEVEL_MAX: f32 = 10.0;
 
-    pub fn new(device: &wgpu::Device, window_size: UVec2, format: r3::TextureFormat, parent_scale: f32) -> Self {
+    pub fn new(
+        device: &wgpu::Device,
+        window_size: UVec2,
+        format: r3::TextureFormat,
+        parent_scale: f32,
+    ) -> Self {
         Self {
             // Set default zoom to the inverse of ui scale to preserve dpi
             state: GraphEditorState::new(1.0 / parent_scale),
@@ -54,7 +59,7 @@ impl GraphEditor {
         let mut event = event.clone();
         let mouse_in_viewport = self
             .raw_mouse_position
-            .map(|pos| viewport_rect.contains(pos))
+            .map(|pos| viewport_rect.scale_from_origin(parent_scale).contains(pos))
             .unwrap_or(false);
 
         #[allow(clippy::single_match)]

--- a/src/application/graph_editor.rs
+++ b/src/application/graph_editor.rs
@@ -83,7 +83,6 @@ impl GraphEditor {
                     );
                 }
                 winit::event::WindowEvent::MouseWheel { delta, .. } if mouse_in_viewport => {
-                    println!("[Node Editor] {:?}", delta);
                     let mouse_pos = if let Some(raw_pos) = self.raw_mouse_position {
                         viewport_relative_position(
                             raw_pos.to_winit(),

--- a/src/application/graph_editor.rs
+++ b/src/application/graph_editor.rs
@@ -15,9 +15,10 @@ impl GraphEditor {
     pub const ZOOM_LEVEL_MIN: f32 = 0.5;
     pub const ZOOM_LEVEL_MAX: f32 = 10.0;
 
-    pub fn new(device: &wgpu::Device, window_size: UVec2, format: r3::TextureFormat) -> Self {
+    pub fn new(device: &wgpu::Device, window_size: UVec2, format: r3::TextureFormat, parent_scale: f32) -> Self {
         Self {
-            state: GraphEditorState::new(),
+            // Set default zoom to the inverse of ui scale to preserve dpi
+            state: GraphEditorState::new(1.0 / parent_scale),
             platform: Platform::new(PlatformDescriptor {
                 // The width here is not really relevant, and will be reset on
                 // the next resize event.

--- a/src/application/inspector.rs
+++ b/src/application/inspector.rs
@@ -1,7 +1,4 @@
-use crate::{
-    graph::graph_editor_egui::editor_state::{self, GraphEditorState},
-    prelude::*,
-};
+use crate::{graph::graph_editor_egui::editor_state::GraphEditorState, prelude::*};
 use egui::*;
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/src/application/inspector.rs
+++ b/src/application/inspector.rs
@@ -1,0 +1,146 @@
+use crate::prelude::*;
+use egui::*;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum InspectorTab {
+    Properties,
+    Spreadsheet,
+}
+
+pub struct InspectorTabs {
+    current_view: InspectorTab,
+    properties: PropertiesTab,
+    spreadsheet: SpreadsheetTab,
+}
+
+impl InspectorTabs {
+    pub fn new() -> Self {
+        Self {
+            current_view: InspectorTab::Properties,
+            properties: PropertiesTab {},
+            spreadsheet: SpreadsheetTab {
+                current_view: SpreadsheetViews::Vertices,
+            },
+        }
+    }
+}
+
+impl Default for InspectorTabs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct PropertiesTab {}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum SpreadsheetViews {
+    Vertices,
+    Halfedges,
+    Faces,
+}
+
+pub struct SpreadsheetTab {
+    pub current_view: SpreadsheetViews,
+}
+
+impl InspectorTabs {
+    pub fn ui(&mut self, ui: &mut Ui, mesh: Option<&HalfEdgeMesh>) {
+        ui.horizontal(|ui| {
+            ui.selectable_value(
+                &mut self.current_view,
+                InspectorTab::Properties,
+                "Inspector",
+            );
+            ui.selectable_value(
+                &mut self.current_view,
+                InspectorTab::Spreadsheet,
+                "Spreadsheet",
+            );
+        });
+        ui.separator();
+        match self.current_view {
+            InspectorTab::Properties => self.properties.ui(ui),
+            InspectorTab::Spreadsheet => self.spreadsheet.ui(ui, mesh),
+        }
+    }
+}
+impl PropertiesTab {
+    fn ui(&self, ui: &mut Ui) {
+        ui.label("The inspector goes here");
+    }
+}
+impl SpreadsheetTab {
+    fn ui(&mut self, ui: &mut Ui, mesh: Option<&HalfEdgeMesh>) {
+        ui.horizontal(|ui| {
+            ui.selectable_value(
+                &mut self.current_view,
+                SpreadsheetViews::Vertices,
+                "Vertices",
+            );
+            ui.selectable_value(&mut self.current_view, SpreadsheetViews::Faces, "Faces");
+            ui.selectable_value(
+                &mut self.current_view,
+                SpreadsheetViews::Halfedges,
+                "Half edges",
+            );
+        });
+
+        if let Some(mesh) = mesh {
+            let scroll_area = ScrollArea::both().auto_shrink([false, false]);
+            scroll_area.show(ui, |ui| match self.current_view {
+                SpreadsheetViews::Vertices => {
+                    // Vertex spreadsheet
+                    Grid::new("vertex-spreadsheet")
+                        .striped(true)
+                        .num_columns(4)
+                        .show(ui, |ui| {
+                            ui.label("");
+                            ui.label("x");
+                            ui.label("y");
+                            ui.label("z");
+                            ui.end_row();
+
+                            for (idx, (_, v)) in mesh.iter_vertices().enumerate() {
+                                ui.label(idx.to_string());
+                                ui.monospace(format!("{: >6.3}", v.position.x));
+                                ui.monospace(format!("{: >6.3}", v.position.y));
+                                ui.monospace(format!("{: >6.3}", v.position.z));
+                                ui.end_row();
+                            }
+                        })
+                }
+                SpreadsheetViews::Halfedges => {
+                    // Halfedge spreadsheet
+                    Grid::new("halfedge-spreadsheet")
+                        .striped(true)
+                        .num_columns(1)
+                        .show(ui, |ui| {
+                            ui.label("");
+                            ui.end_row();
+
+                            for (idx, _) in mesh.iter_halfedges().enumerate() {
+                                ui.label(idx.to_string());
+                                ui.end_row();
+                            }
+                        })
+                }
+                SpreadsheetViews::Faces => {
+                    // Face spreadsheet
+                    Grid::new("halfedge-spreadsheet")
+                        .striped(true)
+                        .num_columns(1)
+                        .show(ui, |ui| {
+                            ui.label("");
+                            ui.end_row();
+
+                            for (idx, _) in mesh.iter_faces().enumerate() {
+                                ui.label(idx.to_string());
+                                ui.end_row();
+                            }
+                        })
+                }
+            });
+        }
+    }
+}

--- a/src/application/inspector.rs
+++ b/src/application/inspector.rs
@@ -1,4 +1,7 @@
-use crate::prelude::*;
+use crate::{
+    graph::graph_editor_egui::editor_state::{self, GraphEditorState},
+    prelude::*,
+};
 use egui::*;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -45,7 +48,12 @@ pub struct SpreadsheetTab {
 }
 
 impl InspectorTabs {
-    pub fn ui(&mut self, ui: &mut Ui, mesh: Option<&HalfEdgeMesh>) {
+    pub fn ui(
+        &mut self,
+        ui: &mut Ui,
+        mesh: Option<&HalfEdgeMesh>,
+        editor_state: &mut GraphEditorState,
+    ) {
         ui.horizontal(|ui| {
             ui.selectable_value(
                 &mut self.current_view,
@@ -60,14 +68,27 @@ impl InspectorTabs {
         });
         ui.separator();
         match self.current_view {
-            InspectorTab::Properties => self.properties.ui(ui),
+            InspectorTab::Properties => self.properties.ui(ui, editor_state),
             InspectorTab::Spreadsheet => self.spreadsheet.ui(ui, mesh),
         }
     }
 }
 impl PropertiesTab {
-    fn ui(&self, ui: &mut Ui) {
-        ui.label("The inspector goes here");
+    fn ui(&self, ui: &mut Ui, editor_state: &mut GraphEditorState) {
+        let graph = &mut editor_state.graph;
+        if let Some(node) = editor_state.selected_node {
+            let node = &graph[node];
+            let inputs = node.inputs.clone();
+            for (param_name, param) in inputs {
+                if graph.connection(param).is_some() {
+                    ui.label(param_name);
+                } else {
+                    graph[param].value_widget(&param_name, ui);
+                }
+            }
+        } else {
+            ui.label("No node selected. Click a node's title to select it.");
+        }
     }
 }
 impl SpreadsheetTab {

--- a/src/application/inspector.rs
+++ b/src/application/inspector.rs
@@ -70,19 +70,33 @@ impl InspectorTabs {
         }
     }
 }
+
+pub fn tiny_checkbox(ui: &mut Ui, value: &mut bool) {
+    let mut child_ui = ui.child_ui(ui.available_rect_before_wrap(), *ui.layout());
+    child_ui.spacing_mut().icon_spacing = 0.0;
+    child_ui.spacing_mut().interact_size = egui::vec2(16.0, 16.0);
+    child_ui.checkbox(value, "");
+    ui.add_space(24.0);
+}
+
 impl PropertiesTab {
     fn ui(&self, ui: &mut Ui, editor_state: &mut GraphEditorState) {
         let graph = &mut editor_state.graph;
         if let Some(node) = editor_state.selected_node {
             let node = &graph[node];
             let inputs = node.inputs.clone();
-            for (param_name, param) in inputs {
-                if graph.connection(param).is_some() {
-                    ui.label(param_name);
-                } else {
-                    graph[param].value_widget(&param_name, ui);
+            ui.vertical(|ui| {
+                for (param_name, param) in inputs {
+                    if graph.connection(param).is_some() {
+                        ui.label(param_name);
+                    } else {
+                        ui.horizontal(|ui| {
+                            tiny_checkbox(ui, &mut graph[param].shown_inline);
+                            graph[param].value_widget(&param_name, ui);
+                        });
+                    }
                 }
-            }
+            });
         } else {
             ui.label("No node selected. Click a node's title to select it.");
         }

--- a/src/application/root_ui.rs
+++ b/src/application/root_ui.rs
@@ -70,7 +70,7 @@ impl RootViewport {
             }
             "inspector" => payload
                 .inspector_tabs
-                .ui(ui, payload.app_context.mesh.as_ref()),
+                .ui(ui, payload.app_context.mesh.as_ref(), &mut payload.graph_editor.state),
             _ => panic!("Invalid split name {}", name),
         }
     }

--- a/src/application/root_ui.rs
+++ b/src/application/root_ui.rs
@@ -68,9 +68,11 @@ impl RootViewport {
                     .unwrap()
                     .show(ui, ui.available_size());
             }
-            "inspector" => payload
-                .inspector_tabs
-                .ui(ui, payload.app_context.mesh.as_ref(), &mut payload.graph_editor.state),
+            "inspector" => payload.inspector_tabs.ui(
+                ui,
+                payload.app_context.mesh.as_ref(),
+                &mut payload.graph_editor.state,
+            ),
             _ => panic!("Invalid split name {}", name),
         }
     }

--- a/src/application/root_ui.rs
+++ b/src/application/root_ui.rs
@@ -8,7 +8,7 @@ pub enum AppRootAction {
 }
 
 impl RootViewport {
-    pub fn top_menubar(ui: &mut egui::Ui) -> Option<AppRootAction> {
+    pub fn top_menubar(&mut self, ui: &mut egui::Ui) -> Option<AppRootAction> {
         let mut action = None;
 
         // When set, will load a new editor state at the end of this function
@@ -32,9 +32,22 @@ impl RootViewport {
                     }
                 }
             });
+            ui.menu_button("Help", |ui| {
+                if ui.button("Diagnosics").clicked() {
+                    self.diagnostics_open = true;
+                }
+            });
         });
 
         action
+    }
+
+    pub fn diagnostics_ui(&mut self, ctx: &egui::CtxRef) {
+        egui::Window::new("Diagnostics")
+            .open(&mut self.diagnostics_open)
+            .show(ctx, |ui| {
+                ui.label(format!("HiDPI scale: {}", ui.ctx().pixels_per_point()));
+            });
     }
 
     pub fn show_leaf(ui: &mut egui::Ui, payload: &mut Self, name: &str) {
@@ -55,9 +68,9 @@ impl RootViewport {
                     .unwrap()
                     .show(ui, ui.available_size());
             }
-            "inspector" => {
-                payload.inspector_tabs.ui(ui, payload.app_context.mesh.as_ref())
-            }
+            "inspector" => payload
+                .inspector_tabs
+                .ui(ui, payload.app_context.mesh.as_ref()),
             _ => panic!("Invalid split name {}", name),
         }
     }

--- a/src/application/root_ui.rs
+++ b/src/application/root_ui.rs
@@ -56,7 +56,7 @@ impl RootViewport {
                     .show(ui, ui.available_size());
             }
             "inspector" => {
-                ui.label("Properties inspector goes here");
+                payload.inspector_tabs.ui(ui, payload.app_context.mesh.as_ref())
             }
             _ => panic!("Invalid split name {}", name),
         }

--- a/src/application/serialization.rs
+++ b/src/application/serialization.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize)]
 struct SerializedEditorState {
     pub graph: Graph,
+    pub node_order: Vec<NodeId>,
     pub active_node: Option<NodeId>,
     pub node_positions: HashMap<NodeId, egui::Pos2>,
     pub pan_zoom: PanZoom,
@@ -19,6 +20,7 @@ impl SerializedEditorState {
     pub fn from_state(editor_state: &GraphEditorState) -> Self {
         SerializedEditorState {
             graph: editor_state.graph.clone(),
+            node_order: editor_state.node_order.clone(),
             active_node: editor_state.active_node,
             node_positions: editor_state.node_positions.clone(),
             pan_zoom: editor_state.pan_zoom,
@@ -28,6 +30,7 @@ impl SerializedEditorState {
     pub fn into_state(self) -> GraphEditorState {
         let mut state = GraphEditorState::new(1.0);
         state.graph = self.graph;
+        state.node_order = self.node_order;
         state.active_node = self.active_node;
         state.node_positions = self.node_positions;
         state.pan_zoom = self.pan_zoom;

--- a/src/application/serialization.rs
+++ b/src/application/serialization.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize)]
 struct SerializedEditorState {
     pub graph: Graph,
-    pub node_order: Vec<NodeId>,
+    pub node_order: Option<Vec<NodeId>>,
     pub active_node: Option<NodeId>,
     pub node_positions: HashMap<NodeId, egui::Pos2>,
     pub pan_zoom: PanZoom,
@@ -20,7 +20,7 @@ impl SerializedEditorState {
     pub fn from_state(editor_state: &GraphEditorState) -> Self {
         SerializedEditorState {
             graph: editor_state.graph.clone(),
-            node_order: editor_state.node_order.clone(),
+            node_order: Some(editor_state.node_order.clone()),
             active_node: editor_state.active_node,
             node_positions: editor_state.node_positions.clone(),
             pan_zoom: editor_state.pan_zoom,
@@ -30,7 +30,9 @@ impl SerializedEditorState {
     pub fn into_state(self) -> GraphEditorState {
         let mut state = GraphEditorState::new(1.0);
         state.graph = self.graph;
-        state.node_order = self.node_order;
+        state.node_order = self
+            .node_order
+            .unwrap_or_else(|| state.graph.iter_nodes().collect());
         state.active_node = self.active_node;
         state.node_positions = self.node_positions;
         state.pan_zoom = self.pan_zoom;

--- a/src/application/serialization.rs
+++ b/src/application/serialization.rs
@@ -26,7 +26,7 @@ impl SerializedEditorState {
     }
 
     pub fn into_state(self) -> GraphEditorState {
-        let mut state = GraphEditorState::new();
+        let mut state = GraphEditorState::new(1.0);
         state.graph = self.graph;
         state.active_node = self.active_node;
         state.node_positions = self.node_positions;

--- a/src/application/viewport_split.rs
+++ b/src/application/viewport_split.rs
@@ -16,16 +16,16 @@ pub struct ViewportSplit {
 }
 
 impl ViewportSplit {
-    pub fn vertical() -> Self {
+    pub fn vertical(fraction: f32) -> Self {
         Self {
-            fraction: 0.5,
+            fraction,
             separator_width: 10.0,
             kind: ViewportSplitKind::Vertical,
         }
     }
-    pub fn horizontal() -> Self {
+    pub fn horizontal(fraction: f32) -> Self {
         Self {
-            fraction: 0.5,
+            fraction,
             separator_width: 10.0,
             kind: ViewportSplitKind::Horizontal,
         }
@@ -156,15 +156,13 @@ impl SplitTree {
 
     pub fn default_tree() -> SplitTree {
         SplitTree::Split {
-            left: Box::new(SplitTree::Leaf("3d_view".into())),
-            /* NOTE: Uncomment once we add the properties inspector
-            Box::new(SplitTree::Split {
-                left: Box::new(SplitTree::Leaf("inspector".into())),
-                right: Box::new(SplitTree::Leaf("3d_view".into())),
-                split: ViewportSplit::horizontal(),
-            }), */
+            left: Box::new(SplitTree::Split {
+                left: Box::new(SplitTree::Leaf("3d_view".into())),
+                right: Box::new(SplitTree::Leaf("inspector".into())),
+                split: ViewportSplit::horizontal(0.66),
+            }),
             right: Box::new(SplitTree::Leaf("graph_editor".into())),
-            split: ViewportSplit::vertical(),
+            split: ViewportSplit::vertical(0.5),
         }
     }
 }

--- a/src/graph/graph_editor_egui.rs
+++ b/src/graph/graph_editor_egui.rs
@@ -184,5 +184,4 @@ pub fn draw_graph_editor(ctx: &CtxRef, state: &mut GraphEditorState) {
         state.selected_node = None;
         state.node_finder = None;
     }
-
 }

--- a/src/graph/graph_editor_egui.rs
+++ b/src/graph/graph_editor_egui.rs
@@ -22,7 +22,7 @@ pub fn draw_graph_editor(ctx: &CtxRef, state: &mut GraphEditorState) {
     // executed at the end of this function.
     let mut delayed_responses: Vec<DrawGraphNodeResponse> = vec![];
 
-    let r = CentralPanel::default().show(ctx, |ui| {
+    CentralPanel::default().show(ctx, |ui| {
 
         /* Draw nodes */
         let nodes = state.graph.iter_nodes().collect::<Vec<_>>(); // avoid borrow checker

--- a/src/graph/graph_editor_egui/editor_state.rs
+++ b/src/graph/graph_editor_egui/editor_state.rs
@@ -32,7 +32,7 @@ pub struct GraphEditorState {
 }
 
 impl GraphEditorState {
-    pub fn new() -> Self {
+    pub fn new(default_zoom: f32) -> Self {
         Self {
             graph: Graph::new(),
             connection_in_progress: None,
@@ -43,15 +43,9 @@ impl GraphEditorState {
             node_finder: None,
             pan_zoom: PanZoom {
                 pan: egui::Vec2::ZERO,
-                zoom: 1.0,
+                zoom: default_zoom,
             },
         }
-    }
-}
-
-impl Default for GraphEditorState {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/src/graph/graph_editor_egui/editor_state.rs
+++ b/src/graph/graph_editor_egui/editor_state.rs
@@ -11,6 +11,9 @@ pub struct PanZoom {
 
 pub struct GraphEditorState {
     pub graph: Graph,
+    /// Nodes are drawn in this order. Draw order is important because nodes
+    /// that are drawn last are on top.
+    pub node_order: Vec<NodeId>,
     /// An ongoing connection interaction: The mouse has dragged away from a
     /// port and the user is holding the click
     pub connection_in_progress: Option<(NodeId, AnyParameterId)>,
@@ -35,6 +38,7 @@ impl GraphEditorState {
     pub fn new(default_zoom: f32) -> Self {
         Self {
             graph: Graph::new(),
+            node_order: Vec::new(),
             connection_in_progress: None,
             active_node: None,
             selected_node: None,
@@ -45,6 +49,7 @@ impl GraphEditorState {
                 pan: egui::Vec2::ZERO,
                 zoom: default_zoom,
             },
+
         }
     }
 }

--- a/src/graph/graph_editor_egui/editor_state.rs
+++ b/src/graph/graph_editor_egui/editor_state.rs
@@ -49,7 +49,6 @@ impl GraphEditorState {
                 pan: egui::Vec2::ZERO,
                 zoom: default_zoom,
             },
-
         }
     }
 }

--- a/src/graph/graph_editor_egui/editor_state.rs
+++ b/src/graph/graph_editor_egui/editor_state.rs
@@ -17,6 +17,9 @@ pub struct GraphEditorState {
     /// The currently active node. A program will be compiled to compute the
     /// result of this node and constantly updated in real-time.
     pub active_node: Option<NodeId>,
+    /// The currently selected node. Some interface actions depend on the
+    /// currently selected node.
+    pub selected_node: Option<NodeId>,
     /// The position of each node.
     pub node_positions: HashMap<NodeId, egui::Pos2>,
     /// The node finder is used to create new nodes.
@@ -34,6 +37,7 @@ impl GraphEditorState {
             graph: Graph::new(),
             connection_in_progress: None,
             active_node: None,
+            selected_node: None,
             run_side_effect: None,
             node_positions: HashMap::new(),
             node_finder: None,

--- a/src/graph/graph_editor_egui/graph_node_ui.rs
+++ b/src/graph/graph_editor_egui/graph_node_ui.rs
@@ -89,15 +89,17 @@ impl<'a> GraphNodeWidget<'a> {
 
             // First pass: Draw the inner fields. Compute port heights
             let inputs = self.graph[self.node_id].inputs.clone();
-            for (param_name, param) in inputs {
-                let height_before = ui.min_rect().bottom();
-                if self.graph.connection(param).is_some() {
-                    ui.label(param_name);
-                } else {
-                    self.graph[param].value_widget(&param_name, ui);
+            for (param_name, param_id) in inputs {
+                if self.graph[param_id].shown_inline {
+                    let height_before = ui.min_rect().bottom();
+                    if self.graph.connection(param_id).is_some() {
+                        ui.label(param_name);
+                    } else {
+                        self.graph[param_id].value_widget(&param_name, ui);
+                    }
+                    let height_after = ui.min_rect().bottom();
+                    input_port_heights.push((height_before + height_after) / 2.0);
                 }
-                let height_after = ui.min_rect().bottom();
-                input_port_heights.push((height_before + height_after) / 2.0);
             }
 
             let outputs = self.graph[self.node_id].outputs.clone();
@@ -323,7 +325,6 @@ impl<'a> GraphNodeWidget<'a> {
         // Movement
         *self.position += window_response.drag_delta();
         if window_response.drag_delta().length_sq() > 0.0 {
-            dbg!(window_response.id);
             responses.push(DrawGraphNodeResponse::RaiseNode(self.node_id));
         }
 

--- a/src/graph/graph_types.rs
+++ b/src/graph/graph_types.rs
@@ -78,6 +78,8 @@ pub struct InputParam {
     kind: InputParamKind,
     /// Back-reference to the node containing this parameter.
     node: NodeId,
+    /// When true, the node is shown inline inside the node graph.
+    pub shown_inline: bool,
 }
 
 impl InputParam {

--- a/src/graph/graph_types.rs
+++ b/src/graph/graph_types.rs
@@ -62,6 +62,10 @@ pub enum InputParamKind {
     ConnectionOrConstant,
 }
 
+fn shown_inline_default() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InputParam {
     id: InputId,
@@ -79,6 +83,7 @@ pub struct InputParam {
     /// Back-reference to the node containing this parameter.
     node: NodeId,
     /// When true, the node is shown inline inside the node graph.
+    #[serde(default = "shown_inline_default")]
     pub shown_inline: bool,
 }
 

--- a/src/graph/graph_types/graph_impls.rs
+++ b/src/graph/graph_types/graph_impls.rs
@@ -34,6 +34,7 @@ impl Graph {
                         metadata: smallvec![],
                         kind: ConnectionOrConstant,
                         node: node_id,
+                        shown_inline: true,
                     },
                     InputDescriptor::Mesh => InputParam {
                         id,
@@ -42,6 +43,7 @@ impl Graph {
                         metadata: smallvec![],
                         kind: ConnectionOnly,
                         node: node_id,
+                        shown_inline: true,
                     },
                     InputDescriptor::Selection => InputParam {
                         id,
@@ -53,6 +55,7 @@ impl Graph {
                         metadata: smallvec![],
                         kind: ConnectionOrConstant,
                         node: node_id,
+                        shown_inline: true,
                     },
                     InputDescriptor::Scalar { default, min, max } => InputParam {
                         id,
@@ -61,6 +64,7 @@ impl Graph {
                         metadata: smallvec![InputParamMetadata::MinMaxScalar { min, max }],
                         kind: ConnectionOrConstant,
                         node: node_id,
+                        shown_inline: true,
                     },
                     InputDescriptor::Enum { values } => InputParam {
                         id,
@@ -72,6 +76,7 @@ impl Graph {
                         metadata: smallvec![],
                         kind: ConstantOnly,
                         node: node_id,
+                        shown_inline: true,
                     },
                     InputDescriptor::NewFile => InputParam {
                         id,
@@ -80,6 +85,7 @@ impl Graph {
                         metadata: smallvec![],
                         kind: ConstantOnly,
                         node: node_id,
+                        shown_inline: true,
                     },
                 });
                 (input_name, input_id)

--- a/src/math.rs
+++ b/src/math.rs
@@ -49,3 +49,19 @@ impl ToWinit<winit::dpi::PhysicalPosition<f64>> for egui::Pos2 {
         }
     }
 }
+
+pub trait ColorUtils {
+    /// Multiplies the color rgb values by `factor`, keeping alpha untouched.
+    fn lighten(&self, factor: f32) -> Self;
+}
+
+impl ColorUtils for egui::Color32 {
+    fn lighten(&self, factor: f32) -> Self {
+        egui::Color32::from_rgba_premultiplied(
+            (self.r() as f32 * factor) as u8,
+            (self.g() as f32 * factor) as u8,
+            (self.b() as f32 * factor) as u8,
+            self.a(),
+        )
+    }
+}

--- a/src/math.rs
+++ b/src/math.rs
@@ -65,3 +65,17 @@ impl ColorUtils for egui::Color32 {
         )
     }
 }
+
+pub trait RectUtils {
+    /// Scales the rect by the given `scale` factor relative to the origin at (0,0)
+    fn scale_from_origin(&self, scale: f32) -> Self;
+}
+
+impl RectUtils for egui::Rect {
+    fn scale_from_origin(&self, scale: f32) -> Self {
+        let mut result = *self;
+        result.min = (self.min.to_vec2() * scale).to_pos2();
+        result.max = (self.max.to_vec2() * scale).to_pos2();
+        result
+    }
+}


### PR DESCRIPTION
# Properties inspector
- [x] A new panel to the right of the 3d viewport
- [x] Nodes can now be selected
- [x] The properties of a selected nodes are shown on the inspector
- [x] Properties can be hidden from the graph

# Spreadsheet panel
- [x] A spreadsheet panel on a separate tab
- [x] Spreadsheet shows information about vertices, halfedges and faces (not much for now)

# Misc.
- [x] Fix #6 and #7
- [x] Nodes are now raised when clicked or dragged