### PR TITLE
Remove nightly requirement and stop requesting unused wgpu feature

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,4 +2,5 @@
 # https://bevyengine.org/learn/book/getting-started/setup/
 [target.x86_64-unknown-linux-gnu]
 linker = "/usr/bin/clang"
-rustflags = ["-Clink-arg=-fuse-ld=lld", "-Zshare-generics=y"]
+rustflags = ["-Clink-arg=-fuse-ld=lld"]
+# rustflags = ["-Clink-arg=-fuse-ld=lld", "-Zshare-generics=y"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,0 @@
-# Bevy's "fast compile times" recommended setup from:
-# https://bevyengine.org/learn/book/getting-started/setup/
-[target.x86_64-unknown-linux-gnu]
-linker = "/usr/bin/clang"
-rustflags = ["-Clink-arg=-fuse-ld=lld"]
-# rustflags = ["-Clink-arg=-fuse-ld=lld", "-Zshare-generics=y"]

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 gen/
 target/
 Cargo.lock
+.cargo/

--- a/src/render_context.rs
+++ b/src/render_context.rs
@@ -27,7 +27,7 @@ impl RenderContext {
             None,
             None,
             None,
-            Some(Features::POLYGON_MODE_LINE),
+            None,
         ))
         .unwrap();
 


### PR DESCRIPTION
- [x] The code was unnecessarily requiring a nightly toolchain due to the present of a `.cargo/config.toml` file tuned for incremental compile speed which is now removed
- [x] The code was also requesting a `POLYGON_MODE_LINE` wgpu feature which is no longer used. This requirement is now removed.