### PR TITLE
Fix typo in documentation comment

### DIFF
--- a/blackjack_engine/src/graph.rs
+++ b/blackjack_engine/src/graph.rs
@@ -327,7 +327,7 @@ impl BjkGraph {
         Ok(())
     }
 
-    /// Registers a new input for `node_id`
+    /// Registers a new output for `node_id`
     pub fn add_output(
         &mut self,
         node_id: BjkNodeId,


### PR DESCRIPTION
change from input to output