### PR TITLE
Fix wgpu validation errors (panic) when window is too small

### DIFF
--- a/blackjack_ui/src/application/graph_editor.rs
+++ b/blackjack_ui/src/application/graph_editor.rs
@@ -268,14 +268,20 @@ impl GraphEditor {
         );
     }
 
+    /// Returns Some(render_target) when the graph should be drawn by the parent
+    /// context.
     pub fn add_draw_to_graph<'node>(
         &'node mut self,
         graph: &mut r3::RenderGraph<'node>,
         viewport_rect: egui::Rect,
         parent_scale: f32,
-    ) -> r3::RenderTargetHandle {
+    ) -> Option<r3::RenderTargetHandle> {
         let resolution = viewport_rect.size() * parent_scale;
         let resolution = UVec2::new(resolution.x as u32, resolution.y as u32);
+
+        if resolution.x == 0 || resolution.y == 0 {
+            return None;
+        }
 
         let render_target = graph.add_render_target(r3::RenderTargetDescriptor {
             label: None,
@@ -295,6 +301,6 @@ impl GraphEditor {
             render_target,
         );
 
-        render_target
+        Some(render_target)
     }
 }

--- a/blackjack_ui/src/application/viewport_3d.rs
+++ b/blackjack_ui/src/application/viewport_3d.rs
@@ -196,28 +196,35 @@ impl Viewport3d {
         Vec4::splat(0.25)
     }
 
-    fn get_resolution(&self) -> UVec2 {
+    pub fn get_resolution(&self) -> UVec2 {
         UVec2::new(
             (self.viewport_rect.width() * self.parent_scale) as u32,
             (self.viewport_rect.height() * self.parent_scale) as u32,
         )
     }
 
+    /// Returns Some(render_target) when the viewport should be drawn by the
+    /// calling context.
     pub fn add_to_graph<'node>(
         &'node mut self,
         graph: &mut r3::RenderGraph<'node>,
         ready: &r3::ReadyData,
         viewport_routines: super::ViewportRoutines<'node>,
-    ) -> r3::RenderTargetHandle {
-        rendergraph::blackjack_viewport_rendergraph(
-            graph,
-            ready,
-            viewport_routines,
-            self.get_resolution(),
-            r3::SampleCount::One,
-            Self::ambient_light(),
-            &self.settings,
-        )
+    ) -> Option<r3::RenderTargetHandle> {
+        let resolution = self.get_resolution();
+        if resolution.x == 0 || resolution.y == 0 {
+            None
+        } else {
+            Some(rendergraph::blackjack_viewport_rendergraph(
+                graph,
+                ready,
+                viewport_routines,
+                self.get_resolution(),
+                r3::SampleCount::One,
+                Self::ambient_light(),
+                &self.settings,
+            ))
+        }
     }
 
     pub fn show_ui(

--- a/blackjack_ui/src/application/viewport_split.rs
+++ b/blackjack_ui/src/application/viewport_split.rs
@@ -46,6 +46,13 @@ impl ViewportSplit {
         view_1: impl FnOnce(&mut Ui, &mut Payload),
         view_2: impl FnOnce(&mut Ui, &mut Payload),
     ) {
+        // HACK: Sometimes, in some window managers / platforms, windows can
+        // end up having zero size. This can lead to NaNs getting their way
+        // into the `fraction` and breaking the UI. This workaround solves it.
+        if self.fraction.is_nan() {
+            self.fraction = 0.5;
+        }
+
         let total_space = ui.available_rect_before_wrap();
         let hsep = self.separator_width * 0.5;
 


### PR DESCRIPTION
Title says it all. I think this might've been introduced by #43, but not sure. Either way, issue's fixed now :+1: 