### PR TITLE
Fix window input issues

### DIFF
--- a/blackjack_ui/src/app_window/input.rs
+++ b/blackjack_ui/src/app_window/input.rs
@@ -71,7 +71,7 @@ impl InputSystem {
             // Cursor moves are always registered. The raw (untransformed) mouse
             // position is also stored so we know if the mosue is over the
             // viewport on the next events.
-            WindowEvent::CursorMoved { position, .. } if mouse_in_viewport => {
+            WindowEvent::CursorMoved { position, .. } => {
                 self.mouse.last_pos_raw = Some(Vec2::new(position.x as f32, position.y as f32));
 
                 let position = viewport_relative_position(
@@ -80,8 +80,12 @@ impl InputSystem {
                     viewport_rect,
                     1.0, // zoom doesn't affect cursor on this viewport
                 );
-                self.mouse
-                    .on_cursor_move(Vec2::new(position.x as f32, position.y as f32));
+                // We always update the raw mouse position, but the real mouse
+                // position is not updated if the mouse is captured elsewhere.
+                if !mouse_captured_elsewhere {
+                    self.mouse
+                        .on_cursor_move(Vec2::new(position.x as f32, position.y as f32));
+                }
             }
             // Wheel events will only get registered when the cursor is inside the viewport
             WindowEvent::MouseWheel { delta, .. } if mouse_in_viewport => match delta {

--- a/blackjack_ui/src/app_window/input.rs
+++ b/blackjack_ui/src/app_window/input.rs
@@ -54,22 +54,24 @@ impl InputSystem {
         event: &WindowEvent,
         parent_scale: f32,
         viewport_rect: egui::Rect,
+        mouse_captured_elsewhere: bool,
     ) {
-        let mouse_in_viewport = self
-            .mouse
-            .last_pos_raw
-            .map(|pos| {
-                viewport_rect
-                    .scale_from_origin(parent_scale)
-                    .contains(egui::pos2(pos.x, pos.y))
-            })
-            .unwrap_or(false);
+        let mouse_in_viewport = !mouse_captured_elsewhere
+            && self
+                .mouse
+                .last_pos_raw
+                .map(|pos| {
+                    viewport_rect
+                        .scale_from_origin(parent_scale)
+                        .contains(egui::pos2(pos.x, pos.y))
+                })
+                .unwrap_or(false);
 
         match event {
             // Cursor moves are always registered. The raw (untransformed) mouse
             // position is also stored so we know if the mosue is over the
             // viewport on the next events.
-            WindowEvent::CursorMoved { position, .. } => {
+            WindowEvent::CursorMoved { position, .. } if mouse_in_viewport => {
                 self.mouse.last_pos_raw = Some(Vec2::new(position.x as f32, position.y as f32));
 
                 let position = viewport_relative_position(

--- a/blackjack_ui/src/application/viewport_3d.rs
+++ b/blackjack_ui/src/application/viewport_3d.rs
@@ -125,9 +125,14 @@ impl Viewport3d {
         parent_scale: f32,
         viewport_rect: egui::Rect,
         event: winit::event::WindowEvent,
+        mouse_captured_elsewhere: bool,
     ) {
-        self.input
-            .on_window_event(&event, parent_scale, viewport_rect);
+        self.input.on_window_event(
+            &event,
+            parent_scale,
+            viewport_rect,
+            mouse_captured_elsewhere,
+        );
     }
 
     fn update_camera(&mut self, render_ctx: &mut RenderContext) {


### PR DESCRIPTION
The PR fixes a couple issues that had to do with mouse input in windows.

- One is described in #41. Which this issue closes.
- The other occurred when using middle or left mouse buttons to drag something, then moving the mouse outside of the graph area. The mouse no longer appears as stuck when doing that.