### PR TITLE
Use wgpu error scopes to prevent crash

### DIFF
--- a/blackjack_ui/src/application.rs
+++ b/blackjack_ui/src/application.rs
@@ -317,7 +317,18 @@ impl RootViewport {
                 face: face_routine,
             },
         );
+
+        // Use error scopes to prevent wgpu validation errors from crashing.
+        render_ctx
+            .renderer
+            .device
+            .push_error_scope(wgpu::ErrorFilter::Validation);
+
         graph.execute(&render_ctx.renderer, frame, cmd_bufs, &ready);
+
+        if let Some(error) = pollster::block_on(render_ctx.renderer.device.pop_error_scope()) {
+            println!("WGPU VALIDATION ERROR: {error}");
+        }
     }
 }
 


### PR DESCRIPTION
There's a very hard to reproduce crash inside `egui-wgpu` due to egui sometimes calling `set_scissor_rect` with invalid sizes. I had circumvented this on my private fork of `egui-wgpu`, but that was removed during #43.

This PR adds a simple fix: wgpu validation errors shouldn't crash blackjack. This PR changes that using error scopes, so errors are logged to console instead.

This means users not paying attention to the console won't notice these errors, but crashing the whole application and losing unsaved progress is not an option.

Here's the crash log:
```
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In a RenderPass
      note: encoder = `<CommandBuffer-(7, 14745, Vulkan)>`
    In a set_scissor_rect command
    Scissor Rect { x: 678, y: 275, w: 106, h: 1 } is not contained in the render target Extent3d { width: 784, height: 275, depth_or_array_layers: 1 }

', /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-0.13.1/src/backend/direct.rs:2391:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```