### PR TITLE
Add `MPL-2.0` SPDX identifier and missing Cargo metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Here are the main goals and philosophy behind blackjack, but note that this show
 - **Error resilience, crash resistance:** When things go wrong, Blackjack will make an effort to *respect your time* as a user and not lose your work. Errors will be clearly communicated and fixing any bugs leading to a crash will take the highest priority.
 
 ## Install and usage
-> **Note:** A crates.io version cannot be published due to unreleased dependencies. Blackjack depends on the bleeding edge version of some crates and requires custom forks for some others. This situation may change once development stabilizes.
+> **Note**: A crates.io version cannot be published due to unreleased dependencies. Blackjack depends on the bleeding edge version of some crates and requires custom forks for some others. This situation may change once development stabilizes.
 
-Here are the steps in order to try out the early development version of Blackjack. Binaries and easier installation methods will be provided in the future. The steps below require a complete Rust toolchain using `cargo`:
+Here are the steps in order to try out the early development version of Blackjack. Binaries and easier installation methods will be provided in the future. The steps below require a complete Rust toolchain using `cargo`, with a minimum supported Rust version (MSRV) of **1.62.0**.
 
 1. Clone this repository, and make sure to download LFS files. In some systems, this may require separately installing a `git-lfs`[^1] package:
 ```bash

--- a/blackjack_commons/Cargo.toml
+++ b/blackjack_commons/Cargo.toml
@@ -5,6 +5,7 @@ homepage = "https://github.com/setzer22/blackjack"
 repository = "https://github.com/setzer22/blackjack"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.62"
 license = "MPL-2.0"
 keywords = ["gamedev", "3d", "modelling", "procedural"]
 authors = ["setzer22"]

--- a/blackjack_commons/Cargo.toml
+++ b/blackjack_commons/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "blackjack_commons"
+description = "A procedural, node-based modelling tool, made in Rust"
+homepage = "https://github.com/setzer22/blackjack"
+repository = "https://github.com/setzer22/blackjack"
 version = "0.1.0"
 edition = "2021"
+license = "MPL-2.0"
+keywords = ["gamedev", "3d", "modelling", "procedural"]
+authors = ["setzer22"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/blackjack_engine/Cargo.toml
+++ b/blackjack_engine/Cargo.toml
@@ -5,6 +5,7 @@ homepage = "https://github.com/setzer22/blackjack"
 repository = "https://github.com/setzer22/blackjack"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.62"
 license = "MPL-2.0"
 keywords = ["gamedev", "3d", "modelling", "procedural"]
 authors = ["setzer22"]

--- a/blackjack_engine/Cargo.toml
+++ b/blackjack_engine/Cargo.toml
@@ -3,11 +3,11 @@ name = "blackjack_engine"
 description = "A procedural, node-based modelling tool, made in Rust"
 homepage = "https://github.com/setzer22/blackjack"
 repository = "https://github.com/setzer22/blackjack"
-license = "MIT"
 version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
 keywords = ["gamedev", "3d", "modelling", "procedural"]
 authors = ["setzer22"]
-edition = "2021"
 
 [features]
 tracy = ["profiling/profile-with-tracy"]

--- a/blackjack_godot/Cargo.toml
+++ b/blackjack_godot/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "blackjack_godot"
+description = "A procedural, node-based modelling tool, made in Rust"
+homepage = "https://github.com/setzer22/blackjack"
+repository = "https://github.com/setzer22/blackjack"
 version = "0.1.0"
 edition = "2021"
+license = "MPL-2.0"
+keywords = ["gamedev", "3d", "modelling", "procedural"]
+authors = ["setzer22"]
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/blackjack_godot/Cargo.toml
+++ b/blackjack_godot/Cargo.toml
@@ -5,6 +5,7 @@ homepage = "https://github.com/setzer22/blackjack"
 repository = "https://github.com/setzer22/blackjack"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.62"
 license = "MPL-2.0"
 keywords = ["gamedev", "3d", "modelling", "procedural"]
 authors = ["setzer22"]

--- a/blackjack_macros/Cargo.toml
+++ b/blackjack_macros/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "blackjack_macros"
+description = "A procedural, node-based modelling tool, made in Rust"
+homepage = "https://github.com/setzer22/blackjack"
+repository = "https://github.com/setzer22/blackjack"
 version = "0.1.0"
 edition = "2021"
+license = "MPL-2.0"
+keywords = ["gamedev", "3d", "modelling", "procedural"]
+authors = ["setzer22"]
 
 [lib]
 proc-macro = true

--- a/blackjack_macros/Cargo.toml
+++ b/blackjack_macros/Cargo.toml
@@ -5,6 +5,7 @@ homepage = "https://github.com/setzer22/blackjack"
 repository = "https://github.com/setzer22/blackjack"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.62"
 license = "MPL-2.0"
 keywords = ["gamedev", "3d", "modelling", "procedural"]
 authors = ["setzer22"]

--- a/blackjack_ui/Cargo.toml
+++ b/blackjack_ui/Cargo.toml
@@ -3,11 +3,11 @@ name = "blackjack_ui"
 description = "A procedural, node-based modelling tool, made in Rust"
 homepage = "https://github.com/setzer22/blackjack"
 repository = "https://github.com/setzer22/blackjack"
-license = "MIT"
 version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
 keywords = ["gamedev", "3d", "modelling", "procedural"]
 authors = ["setzer22"]
-edition = "2021"
 
 [features]
 tracy = ["profiling/profile-with-tracy"]

--- a/blackjack_ui/Cargo.toml
+++ b/blackjack_ui/Cargo.toml
@@ -5,6 +5,7 @@ homepage = "https://github.com/setzer22/blackjack"
 repository = "https://github.com/setzer22/blackjack"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.62"
 license = "MPL-2.0"
 keywords = ["gamedev", "3d", "modelling", "procedural"]
 authors = ["setzer22"]


### PR DESCRIPTION
Changes:
* replaces some occurrences of `"MIT"` with `"MPL-2.0"` (see [SPDX identifier](https://spdx.org/licenses/MPL-2.0.html))
* adds missing metadata to each crate
* uses same order for fields everywhere