### PR TITLE
Headline capitalization/canonicalization of node names. Main menu UX.

### DIFF
--- a/blackjack_engine/src/mesh/halfedge/channels.rs
+++ b/blackjack_engine/src/mesh/halfedge/channels.rs
@@ -108,7 +108,7 @@ pub trait FromToLua {
 macro_rules! impl_from_to_lua {
     (wrapped $t:ident $wrapper:ident) => {
         impl FromToLua for $t {
-            fn cast_to_lua<'lua>(self, lua: &'lua Lua) -> mlua::Value {
+            fn cast_to_lua(self, lua: &Lua) -> mlua::Value {
                 lua_stdlib::$wrapper(self).to_lua(lua).unwrap()
             }
 
@@ -120,7 +120,7 @@ macro_rules! impl_from_to_lua {
     };
     (flat $t:ident) => {
         impl FromToLua for $t {
-            fn cast_to_lua<'lua>(self, lua: &'lua Lua) -> mlua::Value {
+            fn cast_to_lua(self, lua: &Lua) -> mlua::Value {
                 self.to_lua(lua).unwrap()
             }
 

--- a/blackjack_lua/run/core_nodes.lua
+++ b/blackjack_lua/run/core_nodes.lua
@@ -176,7 +176,7 @@ local primitives = {
         returns = "out_mesh",
     },
     MakeLineFromPoints = {
-        label = "Line from points",
+        label = "Line From Points",
         op = function(inputs)
             local points = {}
             -- Parse the point list, separated by space
@@ -244,7 +244,7 @@ local primitives = {
         returns = "out_mesh",
     },
     MakeGrid = {
-        label = "Points grid",
+        label = "Point Grid",
         op = function(inputs)
             return {
                 out_mesh = Primitives.grid(inputs.x, inputs.y, inputs.spacing_x, inputs.spacing_y),
@@ -307,7 +307,7 @@ local primitives = {
 -- Edit ops: Nodes to edit existing meshes
 local edit_ops = {
     BevelEdges = {
-        label = "Bevel edges",
+        label = "Bevel Edges",
         inputs = {
             P.mesh("in_mesh"),
             P.selection("edges"),
@@ -324,7 +324,7 @@ local edit_ops = {
         end,
     },
     ChamferVertices = {
-        label = "Chamfer vertices",
+        label = "Chamfer Vertices",
         inputs = {
             P.mesh("in_mesh"),
             P.selection("vertices"),
@@ -341,7 +341,7 @@ local edit_ops = {
         end,
     },
     ExtrudeFaces = {
-        label = "Extrude faces",
+        label = "Extrude Faces",
         inputs = {
             P.mesh("in_mesh"),
             P.selection("faces"),
@@ -358,7 +358,7 @@ local edit_ops = {
         end,
     },
     CollapseEdge = {
-        label = "Collapse edges",
+        label = "Collapse Edges",
         inputs = {
             P.mesh("in_mesh"),
             P.selection("edges"),
@@ -412,7 +412,7 @@ local edit_ops = {
         end,
     },
     MergeMeshes = {
-        label = "Merge meshes",
+        label = "Merge Meshes",
         inputs = {
             P.mesh("mesh_a"),
             P.mesh("mesh_b"),
@@ -529,7 +529,7 @@ local edit_ops = {
         gizmos = { Gz.tweak_transform("translate", "rotate", "scale") },
     },
     VertexAttribTransfer = {
-        label = "Vertex attribute transfer",
+        label = "Vertex Attribute Transfer",
         inputs = {
             P.mesh("src_mesh"),
             P.mesh("dst_mesh"),
@@ -546,7 +546,7 @@ local edit_ops = {
         end,
     },
     SetFullRangeUVs = {
-        label = "Set full range UVs",
+        label = "Set Full Range UVs",
         inputs = {
             P.mesh("mesh"),
         },
@@ -561,7 +561,7 @@ local edit_ops = {
         end,
     },
     SetMaterial = {
-        label = "Set material",
+        label = "Set Material",
         inputs = {
             P.mesh("mesh"),
             P.selection("faces"),
@@ -578,7 +578,7 @@ local edit_ops = {
         end,
     },
     MakeGroup = {
-        label = "Make group",
+        label = "Group",
         inputs = {
             P.mesh("mesh"),
             P.enum("type", { "Vertex", "Face", "Halfedge" }, 0),
@@ -597,7 +597,7 @@ local edit_ops = {
         end,
     },
     EditChannels = {
-        label = "Edit channels",
+        label = "Edit Channels",
         inputs = {
             P.mesh("mesh"),
             P.enum("channel_key", { "Vertex", "Face", "Halfedge" }, 0),
@@ -654,7 +654,7 @@ local edit_ops = {
         end,
     },
     CopyToPoints = {
-        label = "Copy to points",
+        label = "Copy To Points",
         op = function(inputs)
             return { out_mesh = Ops.copy_to_points(inputs.points, inputs.mesh) }
         end,
@@ -668,7 +668,7 @@ local edit_ops = {
         returns = "out_mesh",
     },
     ExtrudeAlongCurve = {
-        label = "Extrude along curve",
+        label = "Extrude Along Curve",
         op = function(inputs)
             return {
                 out_mesh = Ops.extrude_along_curve(
@@ -689,7 +689,7 @@ local edit_ops = {
         returns = "out_mesh",
     },
     ResampleCurve = {
-        label = "Resample curve",
+        label = "Resample Curve",
         op = function(inputs)
             return {
                 out_mesh = Ops.resample_curve(
@@ -714,7 +714,7 @@ local edit_ops = {
         returns = "out_mesh",
     },
     PointCloud = {
-        label = "Point cloud",
+        label = "Point Cloud",
         op = function(inputs)
             return { out_mesh = inputs.mesh:point_cloud(inputs.points) }
         end,
@@ -729,7 +729,7 @@ local edit_ops = {
     },
     -- TODO: This should be a more generic randomize channel
     RandomizeSize = {
-        label = "Randomize size",
+        label = "Randomize Size",
         op = function(inputs)
             local mesh = inputs.mesh:clone()
             local size_ch = mesh:ensure_channel(Types.VERTEX_ID, Types.F32, "size")
@@ -833,7 +833,7 @@ local math_nodes = {
         end,
     },
     MakeVector = {
-        label = "MakeVector",
+        label = "Vector",
         inputs = {
             P.scalar("x", { default = 0.0 }),
             P.scalar("y", { default = 0.0 }),
@@ -847,7 +847,7 @@ local math_nodes = {
         end,
     },
     VectorMath = {
-        label = "Vector math",
+        label = "Vector Math",
         inputs = {
             P.enum("op", { "Add", "Sub", "Mul" }, 0),
             P.v3("vec_a", vector(0, 0, 0)),
@@ -869,7 +869,7 @@ local math_nodes = {
         end,
     },
     ScalarMath = {
-        label = "Scalar math",
+        label = "Scalar Math",
         inputs = {
             P.enum("op", { "Add", "Sub", "Mul" }, 0),
             P.scalar("x", { default = 0 }),

--- a/blackjack_ui/src/application.rs
+++ b/blackjack_ui/src/application.rs
@@ -121,7 +121,7 @@ impl RootViewport {
         if !CLI_ARGS.disable_lua_watcher {
             lua_runtime
                 .start_file_watcher()
-                .expect("Could not start file watcher.");
+                .expect("Error starting file watcher.");
         }
 
         let gizmo_state = UiNodeGizmoStates::init();
@@ -203,7 +203,7 @@ impl RootViewport {
 
         if let Some(load) = &CLI_ARGS.load {
             self.handle_root_action(AppRootAction::Load(std::path::PathBuf::from(load)))
-                .expect("Error loading scene from cli arg");
+                .expect("Error loading scene from CLI arg.");
         }
     }
 
@@ -214,7 +214,7 @@ impl RootViewport {
             match self.lua_runtime.watch_for_changes() {
                 Ok(true) => {
                     if let Err(err) = self.graph_editor.on_node_definitions_update() {
-                        println!("Error while updating graph after Lua code reload: {err}");
+                        println!("Error while updating graph after Lua code reload: {err}.");
                     }
 
                     // Reset gizmo state when code is reloaded. This helps
@@ -224,7 +224,7 @@ impl RootViewport {
                 }
                 Ok(false) => { /* Do nothing */ }
                 Err(err) => {
-                    println!("Error while reloading Lua code: {err}");
+                    println!("Error while reloading Lua code: {err}.");
                 }
             }
         }
@@ -275,7 +275,7 @@ impl RootViewport {
         for action in actions {
             // TODO: Don't panic, report error to user in modal dialog
             self.handle_root_action(action)
-                .expect("Error executing action");
+                .expect("Error executing action.");
         }
     }
 
@@ -353,7 +353,7 @@ impl RootViewport {
         graph.execute(&render_ctx.renderer, frame, cmd_bufs, &ready);
 
         if let Some(error) = pollster::block_on(render_ctx.renderer.device.pop_error_scope()) {
-            println!("WGPU VALIDATION ERROR: {error}");
+            println!("Error validating WebGPU: {error}.");
         }
 
         let id = id_picking_routine.id_under_mouse(&render_ctx.renderer.device);

--- a/blackjack_ui/src/application/root_ui.rs
+++ b/blackjack_ui/src/application/root_ui.rs
@@ -29,7 +29,6 @@ impl RootViewport {
                         }
                     }
                     ui.separator();
-                    ui.add_enabled_ui(false, |ui| ui.button("Close"));
                     if ui.button("Save As…").clicked() {
                         let file_location = rfd::FileDialog::new()
                             .set_file_name("Untitled.bjk")

--- a/blackjack_ui/src/application/root_ui.rs
+++ b/blackjack_ui/src/application/root_ui.rs
@@ -19,29 +19,33 @@ impl RootViewport {
             // When set, will load a new editor state at the end of this function
             egui::menu::bar(ui, |ui| {
                 ui.menu_button("File", |ui| {
-                    if ui.button("Save 'Jack' As...").clicked() {
+                    ui.add_enabled_ui(false, |ui| ui.button("New"));
+                    if ui.button("Open…").clicked() {
                         let file_location = rfd::FileDialog::new()
-                            .set_file_name("Untitled.bjk")
-                            .add_filter("Blackjack Models", &["bjk"])
-                            .save_file();
-                        if let Some(path) = file_location {
-                            action = Some(AppRootAction::Save(path))
-                        }
-                    }
-                    if ui.button("Load 'Jack'").clicked() {
-                        let file_location = rfd::FileDialog::new()
-                            .add_filter("Blackjack Models", &["bjk"])
+                            .add_filter("Blackjack Model", &["bjk"])
                             .pick_file();
                         if let Some(path) = file_location {
                             action = Some(AppRootAction::Load(path))
                         }
                     }
-                });
-                ui.menu_button("Help", |ui| {
-                    if ui.button("Diagnosics").clicked() {
-                        self.diagnostics_open = true;
+                    ui.separator();
+                    ui.add_enabled_ui(false, |ui| ui.button("Close"));
+                    if ui.button("Save As…").clicked() {
+                        let file_location = rfd::FileDialog::new()
+                            .set_file_name("Untitled.bjk")
+                            .add_filter("Blackjack Model", &["bjk"])
+                            .save_file();
+                        if let Some(path) = file_location {
+                            action = Some(AppRootAction::Save(path))
+                        }
                     }
+                    ui.separator();
+                    ui.add_enabled_ui(false, |ui| ui.button("Quit"));
                 });
+                ui.menu_button("Window", |ui| {
+                    ui.checkbox(&mut self.diagnostics_open, "Diagnostics");
+                });
+
             });
         });
 
@@ -52,7 +56,7 @@ impl RootViewport {
         egui::Window::new("Diagnostics")
             .open(&mut self.diagnostics_open)
             .show(&self.egui_context, |ui| {
-                ui.label(format!("HiDPI scale: {}", ui.ctx().pixels_per_point()));
+                ui.label(format!("HiDPI Scale: {}", ui.ctx().pixels_per_point()));
             });
     }
 

--- a/blackjack_ui/src/application/root_ui.rs
+++ b/blackjack_ui/src/application/root_ui.rs
@@ -44,7 +44,6 @@ impl RootViewport {
                 ui.menu_button("Window", |ui| {
                     ui.checkbox(&mut self.diagnostics_open, "Diagnostics");
                 });
-
             });
         });
 


### PR DESCRIPTION
* Headline-capitalized all node names.
* Made node naming more stringent: some nodes creating stuff have a `Make` prefix, but most do not. So I removed it everywhere.
   This needs more work but rules should be put down first; not least for other developers eventually writing nodes (e.g. use of verbs vs. nouns, use of plural vs. singular etc.)
* Main menu:
   * Added (currently disabled) `New` and `Quit` entries.
   * Switched order of `Save As…`/`Load` (platform standards on Windows, macOS & all Linux desktops that have human interface guidelines).
   * Renamed `Load` to `Open`.
   * Swapped triple dots for real ellipsis and added to `Open…`.
   * Renamed `Help` to `Window`.
   * Fixed spelling of `Diagnostics`.
   * Changed `Diagnostics` toggle button to checkbox.